### PR TITLE
Add recency push. Get oracle specific data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 .idea/
+
+node_modules
+yarn.lock

--- a/bot.js
+++ b/bot.js
@@ -1,28 +1,50 @@
 const near = require("./near");
 const config = require("./config");
-const {IsDifferentEnough} = require("./functions");
+const { IsDifferentEnough } = require("./functions");
 
 module.exports = {
-    updatePrices: function(tickers, old_prices, new_prices) {
-        let prices_to_update = [];
-        tickers.map(ticker => {
-            console.log(`Compare ${ticker}: ${old_prices[ticker].multiplier.toString()} and ${new_prices[ticker].multiplier.toString()}`);
-            if (IsDifferentEnough(old_prices[ticker], new_prices[ticker])) {
-                console.log(`!!! Update ${ticker} price`)
-                prices_to_update.push({
-                    asset_id: ticker,
-                    price: {
-                        multiplier: Math.round(new_prices[ticker].multiplier).toString(),
-                        decimals: new_prices[ticker].decimals
-                    }
-                })
-            }
+  updatePrices: async function (tickers, old_prices, new_prices, last_report) {
+    const current_time = new Date().getTime();
+    const time_from_last_report = current_time - last_report;
+    console.log(
+      `Time from last report: ${(time_from_last_report / 1e3).toFixed(3)} sec`
+    );
+    const time_to_report =
+      time_from_last_report > config.MAX_NO_REPORT_DURATION;
+    const prices_to_update = [];
+    tickers.map((ticker) => {
+      console.log(
+        `Compare ${ticker}: ${old_prices[
+          ticker
+        ].multiplier.toString()} and ${new_prices[
+          ticker
+        ].multiplier.toString()}`
+      );
+      if (
+        time_to_report ||
+        IsDifferentEnough(old_prices[ticker], new_prices[ticker])
+      ) {
+        console.log(`!!! Update ${ticker} price`);
+        prices_to_update.push({
+          asset_id: ticker,
+          price: {
+            multiplier: Math.round(new_prices[ticker].multiplier).toString(),
+            decimals: new_prices[ticker].decimals,
+          },
         });
+      }
+    });
 
-        if (prices_to_update.length) {
-            near.NearCall(config.NEAR_ACCOUNT_ID, config.CONTRACT_ID, "report_prices", {prices: prices_to_update})
-                .then(resp => console.log(resp));
+    if (prices_to_update.length) {
+      const resp = await near.NearCall(
+        config.NEAR_ACCOUNT_ID,
+        config.CONTRACT_ID,
+        "report_prices",
+        {
+          prices: prices_to_update,
         }
-}
-
-}
+      );
+      console.log(resp);
+    }
+  },
+};

--- a/config.js
+++ b/config.js
@@ -1,7 +1,7 @@
 const CONTRACT_NAME = process.env.CONTRACT_NAME || "null_address.testnet";
 
 module.exports = {
-  CONTRACT_ID: process.env.CONTRACT_ID || "dev-1631302633591-50236902542063",
+  CONTRACT_ID: process.env.CONTRACT_ID || "priceoracle.testnet",
   NEAR_ACCOUNT_ID: process.env.NEAR_ACCOUNT_ID || "zavodil.testnet",
   // 50 seconds
   MAX_NO_REPORT_DURATION: process.env.MAX_NO_REPORT_DURATION || 50000,

--- a/config.js
+++ b/config.js
@@ -3,8 +3,18 @@ const CONTRACT_NAME = process.env.CONTRACT_NAME || "null_address.testnet";
 module.exports = {
   CONTRACT_ID: process.env.CONTRACT_ID || "priceoracle.testnet",
   NEAR_ACCOUNT_ID: process.env.NEAR_ACCOUNT_ID || "zavodil.testnet",
-  // 50 seconds
-  MAX_NO_REPORT_DURATION: process.env.MAX_NO_REPORT_DURATION || 50000,
+  // Will report the prices at least every 50 seconds
+  MAX_NO_REPORT_DURATION: process.env.MAX_NO_REPORT_DURATION
+    ? parseFloat(process.env.MAX_NO_REPORT_DURATION)
+    : 50000,
+  // Relative difference. Default 0.005 or 0.5%
+  RELATIVE_DIFF: process.env.RELATIVE_DIFF
+    ? parseFloat(process.env.RELATIVE_DIFF)
+    : 0.005,
+  // Each price is reported with 4 digits after floating point.
+  FRACTION_DIGITS: process.env.FRACTION_DIGITS
+    ? parseInt(process.env.FRACTION_DIGITS)
+    : 4,
 
   API_SERVER_URL: "https://rest.nearapi.org",
   MAINNET_RPC: "https://rpc.mainnet.near.org",

--- a/config.js
+++ b/config.js
@@ -1,68 +1,71 @@
 const CONTRACT_NAME = process.env.CONTRACT_NAME || "null_address.testnet";
 
 module.exports = {
-    CONTRACT_ID: process.env.CONTRACT_ID || "dev-1631302633591-50236902542063",
-    NEAR_ACCOUNT_ID: process.env.NEAR_ACCOUNT_ID || 'zavodil.testnet',
+  CONTRACT_ID: process.env.CONTRACT_ID || "dev-1631302633591-50236902542063",
+  NEAR_ACCOUNT_ID: process.env.NEAR_ACCOUNT_ID || "zavodil.testnet",
+  // 50 seconds
+  MAX_NO_REPORT_DURATION: process.env.MAX_NO_REPORT_DURATION || 50000,
 
-    API_SERVER_URL: "https://rest.nearapi.org",
-    MAINNET_RPC: "https://rpc.mainnet.near.org",
-    getConfig: (env) => {
-        switch (env) {
-
-            case 'production':
-            case 'mainnet':
-                return {
-                    networkId: 'mainnet',
-                    nodeUrl: 'https://rpc.mainnet.near.org',
-                    contractName: CONTRACT_NAME || "null_address.near",
-                    walletUrl: 'https://wallet.near.org',
-                    helperUrl: 'https://helper.mainnet.near.org',
-                    explorerUrl: 'https://explorer.mainnet.near.org',
-                }
-            case 'development':
-            case 'testnet':
-                return {
-                    networkId: 'testnet',
-                    nodeUrl: 'https://rpc.testnet.near.org',
-                    contractName: CONTRACT_NAME || "null_address.testnet",
-                    walletUrl: 'https://wallet.testnet.near.org',
-                    helperUrl: 'https://helper.testnet.near.org',
-                    explorerUrl: 'https://explorer.testnet.near.org',
-                }
-            case 'betanet':
-                return {
-                    networkId: 'betanet',
-                    nodeUrl: 'https://rpc.betanet.near.org',
-                    contractName: CONTRACT_NAME,
-                    walletUrl: 'https://wallet.betanet.near.org',
-                    helperUrl: 'https://helper.betanet.near.org',
-                    explorerUrl: 'https://explorer.betanet.near.org',
-                }
-            case 'local':
-                return {
-                    networkId: 'local',
-                    nodeUrl: 'http://localhost:3030',
-                    keyPath: `${process.env.HOME}/.near/validator_key.json`,
-                    walletUrl: 'http://localhost:4000/wallet',
-                    contractName: CONTRACT_NAME,
-                }
-            case 'test':
-            case 'ci':
-                return {
-                    networkId: 'shared-test',
-                    nodeUrl: 'https://rpc.ci-testnet.near.org',
-                    contractName: CONTRACT_NAME,
-                    masterAccount: 'test.near',
-                }
-            case 'ci-betanet':
-                return {
-                    networkId: 'shared-test-staging',
-                    nodeUrl: 'https://rpc.ci-betanet.near.org',
-                    contractName: CONTRACT_NAME,
-                    masterAccount: 'test.near',
-                }
-            default:
-                throw Error(`Unconfigured environment '${env}'. Can be configured in src/config.js.`)
-        }
+  API_SERVER_URL: "https://rest.nearapi.org",
+  MAINNET_RPC: "https://rpc.mainnet.near.org",
+  getConfig: (env) => {
+    switch (env) {
+      case "production":
+      case "mainnet":
+        return {
+          networkId: "mainnet",
+          nodeUrl: "https://rpc.mainnet.near.org",
+          contractName: CONTRACT_NAME || "null_address.near",
+          walletUrl: "https://wallet.near.org",
+          helperUrl: "https://helper.mainnet.near.org",
+          explorerUrl: "https://explorer.mainnet.near.org",
+        };
+      case "development":
+      case "testnet":
+        return {
+          networkId: "testnet",
+          nodeUrl: "https://rpc.testnet.near.org",
+          contractName: CONTRACT_NAME || "null_address.testnet",
+          walletUrl: "https://wallet.testnet.near.org",
+          helperUrl: "https://helper.testnet.near.org",
+          explorerUrl: "https://explorer.testnet.near.org",
+        };
+      case "betanet":
+        return {
+          networkId: "betanet",
+          nodeUrl: "https://rpc.betanet.near.org",
+          contractName: CONTRACT_NAME,
+          walletUrl: "https://wallet.betanet.near.org",
+          helperUrl: "https://helper.betanet.near.org",
+          explorerUrl: "https://explorer.betanet.near.org",
+        };
+      case "local":
+        return {
+          networkId: "local",
+          nodeUrl: "http://localhost:3030",
+          keyPath: `${process.env.HOME}/.near/validator_key.json`,
+          walletUrl: "http://localhost:4000/wallet",
+          contractName: CONTRACT_NAME,
+        };
+      case "test":
+      case "ci":
+        return {
+          networkId: "shared-test",
+          nodeUrl: "https://rpc.ci-testnet.near.org",
+          contractName: CONTRACT_NAME,
+          masterAccount: "test.near",
+        };
+      case "ci-betanet":
+        return {
+          networkId: "shared-test-staging",
+          nodeUrl: "https://rpc.ci-betanet.near.org",
+          contractName: CONTRACT_NAME,
+          masterAccount: "test.near",
+        };
+      default:
+        throw Error(
+          `Unconfigured environment '${env}'. Can be configured in src/config.js.`
+        );
     }
-}
+  },
+};

--- a/functions.js
+++ b/functions.js
@@ -1,3 +1,5 @@
+const config = require("./config");
+
 module.exports = {
   /**
    * @return {boolean}
@@ -15,7 +17,10 @@ module.exports = {
         ? Math.pow(10, max_decimals - price_new.decimals)
         : 1);
 
-    return Math.abs(new_multiplier - old_multiplier) >= old_multiplier * 0.001; // 0.1%+ diff
+    return (
+      Math.abs(new_multiplier - old_multiplier) >=
+      old_multiplier * config.RELATIVE_DIFF
+    );
   },
 
   /**

--- a/functions.js
+++ b/functions.js
@@ -1,35 +1,40 @@
 module.exports = {
-    /**
-     * @return {boolean}
-     */
-    IsDifferentEnough: function (price_old, price_new) {
-        const max_decimals = Math.max(price_new.decimals, price_old.decimals);
-        const old_multiplier = price_old.multiplier * (price_old.decimals < price_new.decimals ? Math.pow(10, max_decimals - price_old.decimals) : 1);
-        const new_multiplier = price_new.multiplier * (price_new.decimals < price_old.decimals ? Math.pow(10, max_decimals - price_new.decimals) : 1);
+  /**
+   * @return {boolean}
+   */
+  IsDifferentEnough: function (price_old, price_new) {
+    const max_decimals = Math.max(price_new.decimals, price_old.decimals);
+    const old_multiplier =
+      price_old.multiplier *
+      (price_old.decimals < price_new.decimals
+        ? Math.pow(10, max_decimals - price_old.decimals)
+        : 1);
+    const new_multiplier =
+      price_new.multiplier *
+      (price_new.decimals < price_old.decimals
+        ? Math.pow(10, max_decimals - price_new.decimals)
+        : 1);
 
-        return (Math.abs(new_multiplier - old_multiplier) >= old_multiplier * 0.001); // 0.1%+ diff
-    },
+    return Math.abs(new_multiplier - old_multiplier) >= old_multiplier * 0.001; // 0.1%+ diff
+  },
 
-    /**
-     * @return {number}
-     */
-    GetMedianPrice: function (data, ticker) {
-        let values = data.reduce((object, prices) => {
-            if (prices.hasOwnProperty(ticker))
-                object.push(prices[ticker]);
-            return object;
-        }, []);
+  /**
+   * @return {number}
+   */
+  GetMedianPrice: function (data, ticker) {
+    let values = data.reduce((object, prices) => {
+      if (prices.hasOwnProperty(ticker)) object.push(prices[ticker]);
+      return object;
+    }, []);
 
-        if (!values.length)
-            return 0;
+    if (!values.length) return 0;
 
-        values.sort((a, b) => a - b);
+    values.sort((a, b) => a - b);
 
-        let half = Math.floor(values.length / 2);
+    let half = Math.floor(values.length / 2);
 
-        if (values.length % 2)
-            return values[half];
+    if (values.length % 2) return values[half];
 
-        return (values[half - 1] + values[half]) / 2.0;
-    }
+    return (values[half - 1] + values[half]) / 2.0;
+  },
 };

--- a/index.js
+++ b/index.js
@@ -31,8 +31,6 @@ let coins = {
   "dai.fakes.testnet": { decimals: 18, coingecko: "dai", huobi: "daiusdt" },
 };
 
-const fraction_digits = 4;
-
 async function main() {
   const values = await Promise.all([
     binance.getPrices(coins),
@@ -43,11 +41,11 @@ async function main() {
   const tickers = Object.keys(coins);
   const new_prices = tickers.reduce((object, ticker) => {
     let price = GetMedianPrice(values, ticker);
-    const discrepancy_denominator = Math.pow(10, fraction_digits);
+    const discrepancy_denominator = Math.pow(10, config.FRACTION_DIGITS);
 
     object[ticker] = {
       multiplier: Math.round(price * discrepancy_denominator),
-      decimals: coins[ticker].decimals + fraction_digits,
+      decimals: coins[ticker].decimals + config.FRACTION_DIGITS,
     };
     return object;
   }, {});

--- a/index.js
+++ b/index.js
@@ -1,52 +1,79 @@
-const near = require('./near');
-const config = require('./config');
-const bot = require('./bot');
-const coingecko = require('./feeds/coingecko');
-const binance = require('./feeds/binance');
-const binanceFutures = require('./feeds/binance-futures');
-const huobi = require('./feeds/huobi');
-const {GetMedianPrice} = require("./functions");
+const near = require("./near");
+const config = require("./config");
+const bot = require("./bot");
+const coingecko = require("./feeds/coingecko");
+const binance = require("./feeds/binance");
+const binanceFutures = require("./feeds/binance-futures");
+const huobi = require("./feeds/huobi");
+const { GetMedianPrice } = require("./functions");
 
-console.log("Welcome to the Oracle Bot")
+console.log("Welcome to the Oracle Bot");
 
 let coins = {
-    "wrap.testnet": {decimals: 24, coingecko: "near", binance: "NEARUSDT", huobi: "nearusdt"},
-    "weth.fakes.testnet": {decimals: 18, coingecko: "ethereum", binance: "ETHUSDT", huobi: "ethusdt"},
-    "usdt.fakes.testnet": {decimals: 6, coingecko: "tether"},
-    "usdc.fakes.testnet": {decimals: 6, coingecko: "usd-coin", huobi: "usdcusdt"},
-    "dai.fakes.testnet": {decimals: 18, coingecko: "dai", huobi: "daiusdt"}
+  "wrap.testnet": {
+    decimals: 24,
+    coingecko: "near",
+    binance: "NEARUSDT",
+    huobi: "nearusdt",
+  },
+  "weth.fakes.testnet": {
+    decimals: 18,
+    coingecko: "ethereum",
+    binance: "ETHUSDT",
+    huobi: "ethusdt",
+  },
+  "usdt.fakes.testnet": { decimals: 6, coingecko: "tether" },
+  "usdc.fakes.testnet": {
+    decimals: 6,
+    coingecko: "usd-coin",
+    huobi: "usdcusdt",
+  },
+  "dai.fakes.testnet": { decimals: 18, coingecko: "dai", huobi: "daiusdt" },
 };
 
 const fraction_digits = 4;
 
-Promise.all([
-        binance.getPrices(coins),
-        coingecko.getPrices(coins),
-        binanceFutures.getPrices(coins),
-        huobi.getPrices(coins)
-    ]
-).then(values => {
-    const tickers = Object.keys(coins)
-    let new_prices = tickers.reduce((object, ticker) => {
-        let price = GetMedianPrice(values, ticker);
-        const discrepancy_denominator = Math.pow(10, fraction_digits);
+async function main() {
+  const values = await Promise.all([
+    binance.getPrices(coins),
+    coingecko.getPrices(coins),
+    binanceFutures.getPrices(coins),
+    huobi.getPrices(coins),
+  ]);
+  const tickers = Object.keys(coins);
+  const new_prices = tickers.reduce((object, ticker) => {
+    let price = GetMedianPrice(values, ticker);
+    const discrepancy_denominator = Math.pow(10, fraction_digits);
 
-        object[ticker] = {
-            multiplier: Math.round(price * discrepancy_denominator),
-            decimals: coins[ticker].decimals + fraction_digits
-        };
-        return object;
-    }, {});
+    object[ticker] = {
+      multiplier: Math.round(price * discrepancy_denominator),
+      decimals: coins[ticker].decimals + fraction_digits,
+    };
+    return object;
+  }, {});
 
-    near.NearView(config.CONTRACT_ID, "get_price_data", {asset_ids: tickers})
-        .then(response => response.prices)
-        .then(old_prices => old_prices.reduce((obj, item) => Object.assign(obj, {
-            [item.asset_id]:
-                item.price
-                    ? {multiplier: item.price.multiplier, decimals: item.price.decimals}
-                    : {multiplier: 0, decimals: 0}
-        }), {}))
-        .then(old_prices => {
-            bot.updatePrices(tickers, old_prices, new_prices);
-        })
-});
+  const [raw_oracle_price_data, raw_oracle] = await Promise.all([
+    near.NearView(config.CONTRACT_ID, "get_oracle_price_data", {
+      account_id: config.NEAR_ACCOUNT_ID,
+      asset_ids: tickers,
+    }),
+    near.NearView(config.CONTRACT_ID, "get_oracle", {
+      account_id: config.NEAR_ACCOUNT_ID,
+    }),
+  ]);
+
+  const old_prices = raw_oracle_price_data.prices.reduce(
+    (obj, item) =>
+      Object.assign(obj, {
+        [item.asset_id]: item.price
+          ? { multiplier: item.price.multiplier, decimals: item.price.decimals }
+          : { multiplier: 0, decimals: 0 },
+      }),
+    {}
+  );
+  const last_report = parseFloat(raw_oracle.last_report) / 1e6;
+
+  await bot.updatePrices(tickers, old_prices, new_prices, last_report);
+}
+
+main();

--- a/near.js
+++ b/near.js
@@ -1,76 +1,73 @@
 const homedir = require("os").homedir();
 const fs = require("fs");
 const path = require("path");
-const nearApi = require('near-api-js');
-const {getConfig} = require('./config');
+const nearApi = require("near-api-js");
+const { getConfig } = require("./config");
 
-const nearConfig = getConfig(process.env.NODE_ENV || 'development');
+const nearConfig = getConfig(process.env.NODE_ENV || "development");
 const CREDENTIALS_DIR = ".near-credentials/testnet/";
-const GAS = '20000000000000';
-
+const GAS = "20000000000000";
 
 module.exports = {
-    NearView: async function (contract, operation, parameters) {
-        const nearRpc = new nearApi.providers.JsonRpcProvider(nearConfig.nodeUrl);
-        const account = new nearApi.Account({ provider: nearRpc });
+  NearView: async function (contract, operation, parameters) {
+    const nearRpc = new nearApi.providers.JsonRpcProvider(nearConfig.nodeUrl);
+    const account = new nearApi.Account({ provider: nearRpc });
 
-        const view = await account.viewFunction(
-            contract,
-            operation,
-            parameters
-        );
+    const view = await account.viewFunction(contract, operation, parameters);
 
-        return view;
-    },
+    return view;
+  },
 
-    NearCall: async function (account_id, contract, operation, parameters) {
-        const privateKey = await GetPrivateKey(account_id);
+  NearCall: async function (account_id, contract, operation, parameters) {
+    const privateKey = await GetPrivateKey(account_id);
 
-        const keyPair = nearApi.utils.KeyPair.fromString(privateKey);
-        const keyStore = new nearApi.keyStores.InMemoryKeyStore();
-        keyStore.setKey("default", account_id, keyPair);
+    const keyPair = nearApi.utils.KeyPair.fromString(privateKey);
+    const keyStore = new nearApi.keyStores.InMemoryKeyStore();
+    keyStore.setKey("default", account_id, keyPair);
 
-        const near = await nearApi.connect({
-            networkId: "default",
-            deps: {keyStore},
-            masterAccount: account_id,
-            nodeUrl: nearConfig.nodeUrl
+    const near = await nearApi.connect({
+      networkId: "default",
+      deps: { keyStore },
+      masterAccount: account_id,
+      nodeUrl: nearConfig.nodeUrl,
+    });
+
+    const account = await near.account(account_id);
+
+    const call = await account.functionCall({
+      contractId: contract,
+      methodName: operation,
+      args: parameters,
+      gas: GAS,
+      attachedDeposit: "0",
+    });
+
+    try {
+      if (call["status"].hasOwnProperty("SuccessValue")) {
+        let logs = [];
+        call["receipts_outcome"].map((receipts_outcome) => {
+          if (receipts_outcome ?? ["outcome"] ?? ["logs"].length)
+            receipts_outcome["outcome"]["logs"].map((log) => logs.push(log));
         });
-
-        const account = await near.account(account_id);
-
-        const call = await account.functionCall({
-            contractId: contract,
-            methodName: operation,
-            args: parameters,
-            gas: GAS,
-            attachedDeposit: '0'
-        });
-
-        try {
-            if (call["status"].hasOwnProperty("SuccessValue")) {
-                let logs = [];
-                call["receipts_outcome"].map(receipts_outcome => {
-                    if (receipts_outcome ?? ["outcome"] ?? ["logs"].length)
-                        receipts_outcome["outcome"]["logs"].map(log => logs.push(log))
-                });
-                return `Successful operation: ${operation}!\n\r${logs.join("\n\r")}`;
-            } else {
-                return `Failed operation: ${operation}`;
-            }
-        } catch (e) {
-            return "Call processed with unknown result";
-        }
+        return `Successful operation: ${operation}!\n\r${logs.join("\n\r")}`;
+      } else {
+        return `Failed operation: ${operation}`;
+      }
+    } catch (e) {
+      return "Call processed with unknown result";
     }
+  },
 };
 
 const GetPrivateKey = async function (account_id) {
-    const credentialsPath = path.join(homedir, CREDENTIALS_DIR);
-    const keyPath = credentialsPath + account_id + '.json';
-    try {
-        const credentials = JSON.parse(fs.readFileSync(keyPath));
-        return (credentials.private_key);
-    } catch (e) {
-        throw new Error("Key not found for account " + keyPath + ". Error: " + e.message);
-    }
+  const credentialsPath = path.join(homedir, CREDENTIALS_DIR);
+  const keyPath = credentialsPath + account_id + ".json";
+  try {
+    const credentials = JSON.parse(fs.readFileSync(keyPath));
+    return credentials.private_key;
+  } catch (e) {
+    throw new Error(
+      "Key not found for account " + keyPath + ". Error: " + e.message
+    );
+  }
 };

--- a/package.json
+++ b/package.json
@@ -13,15 +13,16 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/zavodil/near-oracle-bot.git"
+    "url": "git+https://github.com/NearDeFi/near-price-oracle-bot.git"
   },
   "author": "",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/zavodil/near-oracle-bot/issues"
+    "url": "https://github.com/NearDeFi/near-price-oracle-bot/issues"
   },
-  "homepage": "https://github.com/zavodil/near-oracle-bot#readme",
+  "homepage": "https://github.com/NearDeFi/near-price-oracle-bot#readme",
   "devDependencies": {
-    "jest": "^27.2.0"
+    "jest": "^27.2.0",
+    "prettier": "^2.4.1"
   }
 }


### PR DESCRIPTION
- Update to use your oracle specific data to avoid depending on common median price and reporting too frequently.
- Add check for the recency of the last data, to push at least every 50 seconds (targeting 60 sec recency). 
- Update default contract id to `priceoracle.testnet`
- Update default diff to 0.5%
- Move some values into the config.
- Reformat JS with prettier