### PR TITLE
Add fix of skipped prices

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -3,14 +3,8 @@ const config = require("./config");
 const { IsDifferentEnough } = require("./functions");
 
 module.exports = {
-  updatePrices: async function (tickers, old_prices, new_prices, last_report) {
+  updatePrices: async function (tickers, old_prices, new_prices) {
     const current_time = new Date().getTime();
-    const time_from_last_report = current_time - last_report;
-    console.log(
-      `Time from last report: ${(time_from_last_report / 1e3).toFixed(3)} sec`
-    );
-    const time_to_report =
-      time_from_last_report > config.MAX_NO_REPORT_DURATION;
     const prices_to_update = [];
     tickers.map((ticker) => {
       const old_price = old_prices[ticker];
@@ -18,17 +12,15 @@ module.exports = {
       console.log(
         `Compare ${ticker}: ${old_price.multiplier.toString()} and ${new_price.multiplier.toString()}`
       );
-      if (time_to_report || IsDifferentEnough(old_price, new_price)) {
+      if (IsDifferentEnough(old_price, new_price) && new_price.multiplier > 0) {
         console.log(`!!! Update ${ticker} price`);
-        if (new_price.multiplier > 0) {
-          prices_to_update.push({
-            asset_id: ticker,
-            price: {
-              multiplier: Math.round(new_price.multiplier).toString(),
-              decimals: new_price.decimals,
-            },
-          });
-        }
+        prices_to_update.push({
+          asset_id: ticker,
+          price: {
+            multiplier: Math.round(new_price.multiplier).toString(),
+            decimals: new_price.decimals,
+          },
+        });
       }
     });
 

--- a/index.js
+++ b/index.js
@@ -95,15 +95,15 @@ async function main() {
     return object;
   }, {});
 
-  const [raw_oracle_price_data, raw_oracle] = await Promise.all([
-    near.NearView(config.CONTRACT_ID, "get_oracle_price_data", {
+  const raw_oracle_price_data = await near.NearView(
+    config.CONTRACT_ID,
+    "get_oracle_price_data",
+    {
       account_id: config.NEAR_ACCOUNT_ID,
       asset_ids: tickers,
-    }),
-    near.NearView(config.CONTRACT_ID, "get_oracle", {
-      account_id: config.NEAR_ACCOUNT_ID,
-    }),
-  ]);
+      recency_duration_sec: Math.floor(config.MAX_NO_REPORT_DURATION / 1000),
+    }
+  );
 
   const old_prices = raw_oracle_price_data.prices.reduce(
     (obj, item) =>
@@ -114,9 +114,8 @@ async function main() {
       }),
     {}
   );
-  const last_report = parseFloat(raw_oracle.last_report) / 1e6;
 
-  await bot.updatePrices(tickers, old_prices, new_prices, last_report);
+  await bot.updatePrices(tickers, old_prices, new_prices);
 }
 
 setTimeout(() => {


### PR DESCRIPTION
When the a price was reported with 1% change, the recent change was not pushed after 50 sec. So the old price expired.