### PR TITLE
Add NEAR/BUSD exchange rate ($ 1:1)

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,6 +37,7 @@ const TestnetCoins = {
     huobi: "usdcusdt",
   },
   "dai.fakes.testnet": { decimals: 18, coingecko: "dai", huobi: "daiusdt" },
+  "nearbusd": { decimals: 24, binance: "NEARBUSD" },
 };
 
 const MainnetCoins = {
@@ -72,6 +73,7 @@ const MainnetCoins = {
     coingecko: "dai",
     huobi: "daiusdt",
   },
+  "nearbusd": { decimals: 24, binance: "NEARBUSD" },
 };
 
 const MainnetComputeCoins = {


### PR DESCRIPTION
USN contract is going to consume NEAR/BUSD exchange rate retrieved through the `priceoracle`.
`nearbusd` asset is introduced. The heads-up is that it's not the name of the real contract.