### PR TITLE
feat: add LiNEAR price to the oracle

### DIFF
--- a/index.js
+++ b/index.js
@@ -123,6 +123,29 @@ const MainnetComputeCoins = {
       }
     },
   },
+  "linear-protocol.near": {
+    dependencyCoin: "wrap.near",
+    computeCall: async (dependencyPrice) => {
+      if (!dependencyPrice) {
+        return null;
+      }
+      try {
+        const rawLiNearPrice = await near.NearView(
+          "linear-protocol.near",
+          "ft_price",
+          {}
+        );
+        const liNearMultiplier = parseFloat(rawLiNearPrice) / 1e24;
+        return {
+          multiplier: Math.round(dependencyPrice.multiplier * liNearMultiplier),
+          decimals: dependencyPrice.decimals,
+        };
+      } catch (e) {
+        console.log(e);
+        return null;
+      }
+    },
+  },
 };
 
 const TestnetComputeCoins = {


### PR DESCRIPTION
To add LiNEAR to Burrow, we need to set up the price oracle for LiNEAR. 

### Implementation

(1) We're able to fetch LiNEAR price relative to NEAR or wNAER's price with the view function call.

```bash
% NEAR_ENV=mainnet near view linear-protocol.near ft_price
```

The example result is

```bash
View call: linear-protocol.near.ft_price()
'1006763216005980768192366'
```

(2) Then we can get the LiNEAR price in USD based on wNEAR's price, and update the price in the oracle. 
