### PR TITLE
Add 1 minute TWAP for wrap.near

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 const near = require("./near");
 const config = require("./config");
 const bot = require("./bot");
+const Twap = require("./twap");
 const coingecko = require("./feeds/coingecko");
 const binance = require("./feeds/binance");
 const binanceFutures = require("./feeds/binance-futures");
@@ -130,6 +131,21 @@ const TestnetComputeCoins = {
     dependencyCoin: "aurora",
     computeCall: async (dependencyPrice) => dependencyPrice,
   },
+  "twrap.testnet": {
+    dependencyCoin: "wrap.testnet",
+    computeCall: (dependencyPrice) => {
+      const twap = new Twap();
+      try {
+        twap.loadTwapHistory("twap_history.json");
+      } catch (err) {
+        console.log(err);
+      }
+      twap.updatePrice("twrap.testnet", dependencyPrice);
+      twap.storeTwapHistory("twap_history.json");
+
+      return twap.getPrice("twrap.testnet");
+    }
+  }
 };
 
 const mainnet = nearConfig.networkId === "mainnet";
@@ -192,7 +208,7 @@ async function main() {
       }),
     {}
   );
-
+  
   await bot.updatePrices(tickers, old_prices, new_prices);
 }
 

--- a/index.js
+++ b/index.js
@@ -126,7 +126,7 @@ const MainnetComputeCoins = {
       }
     },
   },
-  "twrap.near": {
+  "twap.wrap.near": {
     dependencyCoin: "wrap.near",
     computeCall: (dependencyPrice) => {
       const twap = new Twap();
@@ -135,10 +135,10 @@ const MainnetComputeCoins = {
       } catch (err) {
         console.log(err);
       }
-      twap.updatePrice("twrap.near", dependencyPrice);
+      twap.updatePrice("twap.wrap.near", dependencyPrice);
       twap.storeTwapHistory(TWAP_HISTORY_PATH);
 
-      return twap.getPrice("twrap.near");
+      return twap.getPrice("twap.wrap.near");
     }
   }
 };
@@ -148,7 +148,7 @@ const TestnetComputeCoins = {
     dependencyCoin: "aurora",
     computeCall: async (dependencyPrice) => dependencyPrice,
   },
-  "twrap.testnet": {
+  "twap.wrap.testnet": {
     dependencyCoin: "wrap.testnet",
     computeCall: (dependencyPrice) => {
       const twap = new Twap();
@@ -157,10 +157,10 @@ const TestnetComputeCoins = {
       } catch (err) {
         console.log(err);
       }
-      twap.updatePrice("twrap.testnet", dependencyPrice);
+      twap.updatePrice("twap.wrap.testnet", dependencyPrice);
       twap.storeTwapHistory(TWAP_HISTORY_PATH);
 
-      return twap.getPrice("twrap.testnet");
+      return twap.getPrice("twap.wrap.testnet");
     }
   }
 };

--- a/index.js
+++ b/index.js
@@ -9,6 +9,8 @@ const huobi = require("./feeds/huobi");
 const ftx = require("./feeds/ftx");
 const { GetMedianPrice } = require("./functions");
 
+const TWAP_HISTORY_PATH = "./twap_history.json";
+
 console.log("Welcome to the Oracle Bot");
 
 const nearConfig = config.getConfig(process.env.NODE_ENV || "development");
@@ -136,12 +138,12 @@ const TestnetComputeCoins = {
     computeCall: (dependencyPrice) => {
       const twap = new Twap();
       try {
-        twap.loadTwapHistory("twap_history.json");
+        twap.loadTwapHistory(TWAP_HISTORY_PATH);
       } catch (err) {
         console.log(err);
       }
       twap.updatePrice("twrap.testnet", dependencyPrice);
-      twap.storeTwapHistory("twap_history.json");
+      twap.storeTwapHistory(TWAP_HISTORY_PATH);
 
       return twap.getPrice("twrap.testnet");
     }
@@ -208,7 +210,7 @@ async function main() {
       }),
     {}
   );
-  
+
   await bot.updatePrices(tickers, old_prices, new_prices);
 }
 

--- a/index.js
+++ b/index.js
@@ -126,6 +126,21 @@ const MainnetComputeCoins = {
       }
     },
   },
+  "twrap.near": {
+    dependencyCoin: "wrap.near",
+    computeCall: (dependencyPrice) => {
+      const twap = new Twap();
+      try {
+        twap.loadTwapHistory(TWAP_HISTORY_PATH);
+      } catch (err) {
+        console.log(err);
+      }
+      twap.updatePrice("twrap.near", dependencyPrice);
+      twap.storeTwapHistory(TWAP_HISTORY_PATH);
+
+      return twap.getPrice("twrap.near");
+    }
+  }
 };
 
 const TestnetComputeCoins = {

--- a/tests/twap.test.js
+++ b/tests/twap.test.js
@@ -1,0 +1,237 @@
+const Twap = require("../twap");
+
+beforeAll(() => {
+    jest.useFakeTimers('modern');
+});
+
+afterAll(() => {
+    jest.useRealTimers();
+});
+
+const MakeNum = (multiplier, decimals) => {
+    return {multiplier, decimals}
+}
+
+
+test('Test_TwapUpdatePrices', () => {
+    const twap = new Twap();
+
+    // Test two tickers
+    jest.setSystemTime(new Date(10000));
+    twap.updatePrices(["t1", "t2"], {"t1": MakeNum(10000, 1), "t2": MakeNum(20000, 1)});
+    var shouldBe = {
+        "t1": [
+            {
+                "price": MakeNum(10000, 1),
+                "timestamp": 10000,
+                "cumulative": 0
+            }
+        ],
+        "t2": [
+            {
+                "price": MakeNum(20000, 1),
+                "timestamp": 10000,
+                "cumulative": 0
+            }
+        ]
+    };
+    expect(twap.twap_history).toEqual(shouldBe);
+
+    // Test appending prices
+    jest.setSystemTime(new Date(10001));
+    var shouldBe = {
+        "t1": [
+            {
+                "price": MakeNum(10000, 1),
+                "timestamp": 10000,
+                "cumulative": 0
+            },
+            {
+                "price": MakeNum(30000, 1),
+                "timestamp": 10001,
+                "cumulative": 30000
+            }
+        ],
+        "t2": [
+            {
+                "price": MakeNum(20000, 1),
+                "timestamp": 10000,
+                "cumulative": 0
+            }
+        ]
+    };
+    twap.updatePrices(["t1"], {"t1": MakeNum(30000, 1)});
+    expect(twap.twap_history).toEqual(shouldBe);
+
+    // Test appending prices
+    jest.setSystemTime(new Date(10060));
+    var shouldBe = {
+        "t1": [
+            {
+                "price": MakeNum(10000, 1),
+                "timestamp": 10000,
+                "cumulative": 0
+            },
+            {
+                "price": MakeNum(30000, 1),
+                "timestamp": 10001,
+                "cumulative": 30000
+            },
+            {
+                "price": MakeNum(30003, 1),
+                "timestamp": 10060,
+                "cumulative": 1800177
+            }
+        ],
+        "t2": [
+            {
+                "price": MakeNum(20000, 1),
+                "timestamp": 10000,
+                "cumulative": 0
+            }
+        ]
+    };
+    twap.updatePrices(["t1"], {"t1": MakeNum(30003, 1)});
+    expect(twap.twap_history).toEqual(shouldBe);
+
+    // Test removing old prices
+    jest.setSystemTime(new Date(90000));
+    var shouldBe = {
+        "t1": [
+            {
+                "price": MakeNum(40000, 1),
+                "timestamp": 90000,
+                "cumulative": 0
+            }
+        ],
+        "t2": [
+            {
+                "price": MakeNum(20000, 1),
+                "timestamp": 10000,
+                "cumulative": 0
+            }
+        ]
+    };
+    twap.updatePrices(["t1"], {"t1": MakeNum(40000, 1)});
+    expect(twap.twap_history).toEqual(shouldBe);
+
+    // Test removing old prices (time delta is 59 seconds)
+    jest.setSystemTime(new Date(149999));
+    var shouldBe = {
+        "t1": [
+            {
+                "price": MakeNum(40000, 1),
+                "timestamp": 90000,
+                "cumulative": 0
+            },
+            {
+                "price": MakeNum(40000, 1),
+                "timestamp": 149999,
+                "cumulative": 2399960000
+            }
+        ],
+        "t2": [
+            {
+                "price": MakeNum(40000, 1),
+                "timestamp": 149999,
+                "cumulative": 0
+            }
+        ]
+    };
+    twap.updatePrices(["t1", "t2"], {"t1": MakeNum(40000, 1), "t2": MakeNum(40000, 1)});
+    expect(twap.twap_history).toEqual(shouldBe);
+
+    // Test removing old prices (time delta is 60 seconds)
+    jest.setSystemTime(new Date(150000));
+    var shouldBe = {
+        "t1": [
+            {
+                "price": MakeNum(40000, 1),
+                "timestamp": 149999,
+                "cumulative": 2399960000
+            },
+            {
+                "price": MakeNum(40000, 1),
+                "timestamp": 150000,
+                "cumulative": 2400000000
+            }
+        ],
+        "t2": [
+            {
+                "price": MakeNum(40000, 1),
+                "timestamp": 149999,
+                "cumulative": 0
+            },
+            {
+                "price": MakeNum(40000, 1),
+                "timestamp": 150000,
+                "cumulative": 40000
+            }
+        ]
+    };
+    twap.updatePrices(["t1", "t2"], {"t1": MakeNum(40000, 1), "t2": MakeNum(40000, 1)});
+    expect(twap.twap_history).toEqual(shouldBe);
+});
+
+test('Test_GetPrice', () => {
+    const twap = new Twap();
+
+    // Test empty TWAP history
+    var shouldBe = MakeNum(0, 0);
+    expect(twap.getPrice("t1")).toEqual(shouldBe);
+
+    // Test the case when TWAP contains only one item
+    jest.setSystemTime(new Date(10000));
+    var shouldBe = MakeNum(1234, 1);
+    twap.updatePrice("t1", shouldBe);
+    expect(twap.getPrice("t1")).toEqual(shouldBe);
+
+    // Test the case when the time delta between the oldest and the newest items
+    // is less than 50 sec
+    jest.setSystemTime(new Date(11000));
+    var shouldBe = MakeNum(5, 1);
+    twap.updatePrice("t1", shouldBe);
+    expect(twap.getPrice("t1")).toEqual(shouldBe);
+
+    // Test the case when the time delta between the oldest and the newest items
+    // is 50 sec
+    jest.setSystemTime(new Date(60000));
+    twap.updatePrice("t1", MakeNum(6, 1));
+    var shouldBe = MakeNum(5.98, 1);
+    expect(twap.getPrice("t1")).toEqual(shouldBe);
+
+    // Test the case when the time delta between the oldest and the newest items
+    // is more than 60 sec
+    jest.setSystemTime(new Date(70000));
+    twap.updatePrice("t1", MakeNum(7, 1));
+    var shouldBe = MakeNum(6.169491525423729, 1);
+    expect(twap.getPrice("t1")).toEqual(shouldBe);
+});
+
+test('Test_GetPrices', () => {
+    const twap = new Twap();
+
+    jest.setSystemTime(new Date(10000));
+    twap.updatePrice("t1", MakeNum(12345, 1));
+    twap.updatePrice("t2", MakeNum(321, 1));
+
+    jest.setSystemTime(new Date(45000));
+    twap.updatePrice("t1", MakeNum(7123, 1));
+    twap.updatePrice("t2", MakeNum(6123, 1));
+
+    var shouldBe = {
+        "t1": MakeNum(7123, 1),
+        "t2": MakeNum(6123, 1)
+    }
+    expect(twap.getPrices(["t1", "t2"])).toEqual(shouldBe);
+
+    jest.setSystemTime(new Date(65000));
+    twap.updatePrice("t1", MakeNum(9123, 1));
+    twap.updatePrice("t2", MakeNum(8123, 1));
+
+    var shouldBe = {
+        "t1": MakeNum(7850.272727272727, 1),
+        "t2": MakeNum(6850.272727272727, 1)
+    }
+    expect(twap.getPrices(["t1", "t2"])).toEqual(shouldBe);
+});

--- a/twap.js
+++ b/twap.js
@@ -1,0 +1,106 @@
+const fs = require("fs");
+
+const ONE_MINUTE = 60 * 1000;
+const FIFTY_SECONDS = 50 * 1000;
+
+class Twap {
+  constructor() {
+    this.twap_history = {};
+  }
+
+  loadTwapHistory(file_path) {
+    const data = fs.readFileSync(file_path);
+    const json_data = JSON.parse(data);
+    this.twap_history = sortByTimestamp(json_data);
+  }
+
+  storeTwapHistory(file_path) {
+    const json_str = JSON.stringify(this.twap_history, null, 2);
+    fs.writeFileSync(file_path, json_str);
+  }
+
+  updatePrice(ticker, price) {
+    const current_time = new Date().getTime();
+    const one_munite_ago = current_time - ONE_MINUTE;
+
+    if (this.twap_history.hasOwnProperty(ticker)) {
+      // Remove stale records
+      this.twap_history[ticker] = this.twap_history[ticker].filter((e) => {return e["timestamp"] > one_munite_ago;});
+    } else {
+      this.twap_history[ticker] = [];
+    }
+
+    var new_price = {
+      timestamp: current_time,
+      price: price,
+      cumulative: 0
+    };
+    if (this.twap_history[ticker].length > 0) {
+      const length = this.twap_history[ticker].length;
+      const last_price = this.twap_history[ticker][length - 1];
+      const time_diff = current_time - last_price["timestamp"];
+      const cumulative = time_diff * price["multiplier"] + last_price["cumulative"];
+
+      new_price.cumulative = cumulative;
+    }
+    this.twap_history[ticker].push(new_price);
+  }
+
+  updatePrices(tickers, prices) {
+    tickers.map((ticker) => this.updatePrice(ticker, prices[ticker]))
+  }
+
+  getPrice(ticker) {
+    if (!this.twap_history.hasOwnProperty(ticker)) {
+      return {decimals: 0, multiplier: 0};
+    }
+
+    const length = this.twap_history[ticker].length;
+
+    if (length == 0) {
+      return {decimals: 0, multiplier: 0};
+    }
+
+    if (length == 1) {
+      const price = this.twap_history[ticker][0]["price"]
+      return price;
+    }
+
+    const price1 = this.twap_history[ticker][0];
+    const price2 = this.twap_history[ticker][length - 1];
+    const time_diff = price2["timestamp"] - price1["timestamp"];
+
+    if (time_diff < FIFTY_SECONDS) {
+      return price2["price"];
+    }
+
+    const multiplier = (price2["cumulative"] - price1["cumulative"]) / time_diff;
+
+    return {decimals: price2["price"]["decimals"], multiplier: multiplier};
+  }
+
+  getPrices() {
+    var prices = {};
+    for (var ticker in this.twap_history) {
+      prices[ticker] = this.getPrice(ticker);
+    }
+    return prices;
+  }
+}
+
+function sortByTimestamp(twap_history) {
+  for (var key in twap_history) {
+    twap_history[key] = twap_history[key].sort((a, b) => {
+      if (a["timestamp"] < b["timestamp"]) {
+        return -1;
+      }
+      if (a["timestamp"] > b["timestamp"]) {
+        return 1;
+      }
+      return 0;
+    });
+  }
+  return twap_history;
+}
+
+module.exports = Twap


### PR DESCRIPTION
Add 1 minute TWAP for wrap.near

1. New asset "twrap.near" has been added for TWAP "wrap.near".
2. TWAP history is stored to "twap_history.json" (only last 60 seconds).
3. If the history is too short (less than 50 seconds), TWAP returns the newest price from the history. 