### PR TITLE
Fix issue of bot not reporting prices for one of the null

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -9,7 +9,7 @@ module.exports = {
     const all_prices_updates = [];
     tickers.map((ticker) => {
       const old_price = old_prices[ticker];
-      const new_price = new_prices[ticker];
+      const new_price = new_prices[ticker] || { multiplier: 0, decimals: 0 };
       console.log(
         `Compare ${ticker}: ${old_price.multiplier.toString()} and ${new_price.multiplier.toString()}`
       );


### PR DESCRIPTION
When one of the new prices was `null`, the bot.js failed to report any prices