### PR TITLE
Enable aurora token on mainnet

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -3,11 +3,11 @@ const config = require("./config");
 const { IsDifferentEnough } = require("./functions");
 
 module.exports = {
-  updatePrices: async function (tickers, old_prices, new_prices, state) {
+  updatePrices: async function (relativeDiffs, old_prices, new_prices, state) {
     const current_time = new Date().getTime();
     let prices_to_update = [];
     const all_prices_updates = [];
-    tickers.map((ticker) => {
+    Object.entries(relativeDiffs).map(([ticker, relativeDiff]) => {
       const old_price = old_prices[ticker];
       const new_price = new_prices[ticker] || { multiplier: 0, decimals: 0 };
       console.log(
@@ -22,7 +22,7 @@ module.exports = {
           },
         };
         all_prices_updates.push(price_update);
-        if (IsDifferentEnough(old_price, new_price)) {
+        if (IsDifferentEnough(relativeDiff, old_price, new_price)) {
           console.log(`!!! Update ${ticker} price`);
           prices_to_update.push(price_update);
         }

--- a/feeds/crypto.com.js
+++ b/feeds/crypto.com.js
@@ -1,26 +1,35 @@
 module.exports = {
-    getPrices: async function (coins) {
-        let tickers_to_process = Object.keys(coins)
-            .filter(ticker => coins[ticker].cryptocom);
+  getPrices: async function (coins) {
+    let tickers_to_process = Object.keys(coins).filter(
+      (ticker) => coins[ticker].cryptocom
+    );
 
-        let tickers_prepared = tickers_to_process.reduce((object, ticker) => {
-            object[coins[ticker].cryptocom] = ticker;
-            return object
+    let tickers_prepared = tickers_to_process.reduce((object, ticker) => {
+      object[coins[ticker].cryptocom] = ticker;
+      return object;
+    }, {});
+
+    return Promise.all(
+      tickers_to_process.map((ticker) =>
+        fetch(
+          `https://api.crypto.com/v2/public/get-ticker?instrument_name=${coins[ticker].cryptocom}`
+        )
+      )
+    )
+      .then((responses) => Promise.all(responses.map((res) => res.json())))
+      .then((values) => {
+        return values.reduce((object, price) => {
+          if (price?.result?.data?.t >= Date.now() - 10000) {
+            let ticker = price.result.data.i;
+            // last trade https://exchange-docs.crypto.com/spot/index.html#public-get-ticker
+            object[tickers_prepared[ticker]] =
+              (price.result.data.b + price.result.data.k) / 2;
+            return object;
+          }
         }, {});
-
-        return Promise.all(tickers_to_process.map(ticker => fetch(`https://api.crypto.com/v2/public/get-ticker?instrument_name=${coins[ticker].cryptocom}`)))
-            .then(responses => Promise.all(responses.map(res => res.json())))
-            .then(values => {
-                return values.reduce((object, price) => {
-                    if(price?.result?.data?.t >= Date.now() - 10000) {
-                        let ticker = price.result.data.i;
-                        // last trade https://exchange-docs.crypto.com/spot/index.html#public-get-ticker
-                        object [tickers_prepared[ticker]] = parseFloat(price.result.data.a);
-                        return object;
-                    }
-                }, {})
-            }).catch(function(error) {
-                console.error(error)
-            })
-    }
-}
+      })
+      .catch(function (error) {
+        console.error(error);
+      });
+  },
+};

--- a/feeds/crypto.com.js
+++ b/feeds/crypto.com.js
@@ -1,3 +1,4 @@
+const {GetAvgPrice} = require("../functions");
 module.exports = {
   getPrices: async function (coins) {
     let tickers_to_process = Object.keys(coins).filter(
@@ -20,10 +21,9 @@ module.exports = {
       .then((values) => {
         return values.reduce((object, price) => {
           if (price?.result?.data?.t >= Date.now() - 10000) {
-            let ticker = price.result.data.i;
-            // last trade https://exchange-docs.crypto.com/spot/index.html#public-get-ticker
-            object[tickers_prepared[ticker]] =
-              (price.result.data.b + price.result.data.k) / 2;
+            let ticker = price?.result?.data?.i;
+            // https://exchange-docs.crypto.com/spot/index.html#public-get-ticker
+            object[tickers_prepared[ticker]] = GetAvgPrice(price?.result?.data?.b, price?.result?.data?.k, price?.result?.data?.a);
             return object;
           }
         }, {});

--- a/feeds/gate.js
+++ b/feeds/gate.js
@@ -1,3 +1,4 @@
+const {GetAvgPrice} = require("../functions");
 module.exports = {
   getPrices: async function (coins) {
     let tickers_to_process = Object.keys(coins).filter(
@@ -13,8 +14,7 @@ module.exports = {
       .then((values) => {
         return values.reduce((object, price, index) => {
           if (price.result === "true") {
-            object[tickers_to_process[index]] =
-              (parseFloat(price.lowestAsk) + parseFloat(price.highestBid)) / 2;
+            object[tickers_to_process[index]] = GetAvgPrice(price?.lowestAsk, price?.highestBid, price?.last);
             return object;
           }
         }, {});

--- a/feeds/gate.js
+++ b/feeds/gate.js
@@ -14,7 +14,7 @@ module.exports = {
       .then((values) => {
         return values.reduce((object, price, index) => {
           if (price.result === "true") {
-            object[tickers_to_process[index]] = GetAvgPrice(price?.lowestAsk, price?.highestBid, price?.last);
+            object[tickers_to_process[index]] = GetAvgPrice(price?.highestBid, price?.lowestAsk, price?.last);
             return object;
           }
         }, {});

--- a/feeds/gate.js
+++ b/feeds/gate.js
@@ -1,20 +1,26 @@
 module.exports = {
-    getPrices: async function (coins) {
-        let tickers_to_process = Object.keys(coins)
-            .filter(ticker => coins[ticker].gate);
+  getPrices: async function (coins) {
+    let tickers_to_process = Object.keys(coins).filter(
+      (ticker) => coins[ticker].gate
+    );
 
-        return Promise.all(tickers_to_process.map(ticker => fetch(`https://data.gateapi.io/api2/1/ticker/${coins[ticker].gate}`)))
-            .then(responses => Promise.all(responses.map(res => res.json())))
-            .then(values => {
-                return values.reduce((object, price, index) => {
-                    if(price.result === "true") {
-                        object [tickers_to_process[index]] = parseFloat(price.last)
-                        return object;
-                    }
-                }, {})
-            })
-            .catch(function(error) {
-                console.error(error)
-            })
-    }
-}
+    return Promise.all(
+      tickers_to_process.map((ticker) =>
+        fetch(`https://data.gateapi.io/api2/1/ticker/${coins[ticker].gate}`)
+      )
+    )
+      .then((responses) => Promise.all(responses.map((res) => res.json())))
+      .then((values) => {
+        return values.reduce((object, price, index) => {
+          if (price.result === "true") {
+            object[tickers_to_process[index]] =
+              (parseFloat(price.lowestAsk) + parseFloat(price.highestBid)) / 2;
+            return object;
+          }
+        }, {});
+      })
+      .catch(function (error) {
+        console.error(error);
+      });
+  },
+};

--- a/feeds/huobi.js
+++ b/feeds/huobi.js
@@ -1,24 +1,23 @@
 module.exports = {
     getPrices: async function (coins) {
-        let tickers_to_process = Object.keys(coins)
-            .filter(ticker => coins[ticker].huobi);
+        let tickers_to_process = Object.keys(coins).filter(
+            (ticker) => coins[ticker].huobi
+        );
 
-        let tickers_prepared = tickers_to_process.reduce((object, ticker) => {
-            object[coins[ticker].huobi] = ticker;
-            return object
-        }, {});
-
-        return Promise.all(tickers_to_process.map(ticker => fetch(`https://api.huobi.pro/market/trade?symbol=${coins[ticker].huobi}`)))
-            .then(responses => Promise.all(responses.map(res => res.json())))
-            .then(values => {
-                return values.reduce((object, price) => {
-                    const ticker = price.ch.match("market\.(.*?)\.trade\.detail")[1];
-                    object [tickers_prepared[ticker]] = parseFloat(price?.tick?.data[0]?.price)
-                    return object;
-                }, {})
-            })
-            .catch(function (error) {
-                console.error(error)
-            })
-    }
+        let prices = {};
+        await Promise.all(
+            tickers_to_process.map((ticker) =>
+                (async () => {
+                    let res = await fetch(
+                        `https://api.huobi.pro/market/detail/merged?symbol=${coins[ticker].huobi}`
+                    );
+                    res = await res.json();
+                    prices[ticker] = (res.tick.bid[0] + res.tick.ask[0]) / 2;
+                })().catch(function (error) {
+                    console.error(error);
+                })
+            )
+        );
+        return prices;
+    },
 };

--- a/feeds/huobi.js
+++ b/feeds/huobi.js
@@ -1,24 +1,23 @@
 module.exports = {
-    getPrices: async function (coins) {
-        let tickers_to_process = Object.keys(coins)
-            .filter(ticker => coins[ticker].huobi);
+  getPrices: async function (coins) {
+    let tickers_to_process = Object.keys(coins).filter(
+      (ticker) => coins[ticker].huobi
+    );
 
-        let tickers_prepared = tickers_to_process.reduce((object, ticker) => {
-            object[coins[ticker].huobi] = ticker;
-            return object
-        }, {});
-
-        return Promise.all(tickers_to_process.map(ticker => fetch(`https://api.huobi.pro/market/trade?symbol=${coins[ticker].huobi}`)))
-            .then(responses => Promise.all(responses.map(res => res.json())))
-            .then(values => {
-                return values.reduce((object, price) => {
-                    const ticker = price.ch.match("market\.(.*?)\.trade\.detail")[1];
-                    object [tickers_prepared[ticker]] = parseFloat(price.tick.data[0].price)
-                    return object;
-                }, {})
-            })
-            .catch(function (error) {
-                console.error(error)
-            })
-    }
-}
+    let prices = {};
+    await Promise.all(
+      tickers_to_process.map((ticker) =>
+        (async () => {
+          let res = await fetch(
+            `https://api.huobi.pro/market/detail/merged?symbol=${coins[ticker].huobi}`
+          );
+          res = await res.json();
+          prices[ticker] = (res.tick.bid[0] + res.tick.ask[0]) / 2;
+        })().catch(function (error) {
+          console.error(error);
+        })
+      )
+    );
+    return prices;
+  },
+};

--- a/feeds/huobi.js
+++ b/feeds/huobi.js
@@ -1,23 +1,24 @@
 module.exports = {
-  getPrices: async function (coins) {
-    let tickers_to_process = Object.keys(coins).filter(
-      (ticker) => coins[ticker].huobi
-    );
+    getPrices: async function (coins) {
+        let tickers_to_process = Object.keys(coins)
+            .filter(ticker => coins[ticker].huobi);
 
-    let prices = {};
-    await Promise.all(
-      tickers_to_process.map((ticker) =>
-        (async () => {
-          let res = await fetch(
-            `https://api.huobi.pro/market/detail/merged?symbol=${coins[ticker].huobi}`
-          );
-          res = await res.json();
-          prices[ticker] = (res.tick.bid[0] + res.tick.ask[0]) / 2;
-        })().catch(function (error) {
-          console.error(error);
-        })
-      )
-    );
-    return prices;
-  },
+        let tickers_prepared = tickers_to_process.reduce((object, ticker) => {
+            object[coins[ticker].huobi] = ticker;
+            return object
+        }, {});
+
+        return Promise.all(tickers_to_process.map(ticker => fetch(`https://api.huobi.pro/market/trade?symbol=${coins[ticker].huobi}`)))
+            .then(responses => Promise.all(responses.map(res => res.json())))
+            .then(values => {
+                return values.reduce((object, price) => {
+                    const ticker = price.ch.match("market\.(.*?)\.trade\.detail")[1];
+                    object [tickers_prepared[ticker]] = parseFloat(price?.tick?.data[0]?.price)
+                    return object;
+                }, {})
+            })
+            .catch(function (error) {
+                console.error(error)
+            })
+    }
 };

--- a/feeds/kucoin.js
+++ b/feeds/kucoin.js
@@ -1,3 +1,4 @@
+const {GetAvgPrice} = require("../functions");
 module.exports = {
   getPrices: async function (coins) {
     let tickers_to_process = Object.keys(coins).filter(
@@ -15,10 +16,7 @@ module.exports = {
       .then((values) => {
         return values.reduce((object, price, index) => {
           if (price.data) {
-            object[tickers_to_process[index]] =
-              (parseFloat(price.data.bestBid) +
-                parseFloat(price.data.bestAsk)) /
-              2;
+            object[tickers_to_process[index]] = GetAvgPrice(price?.data?.bestBid, price?.data?.bestAsk, price?.data?.price);
             return object;
           }
         }, {});

--- a/feeds/kucoin.js
+++ b/feeds/kucoin.js
@@ -1,20 +1,30 @@
 module.exports = {
-    getPrices: async function (coins) {
-        let tickers_to_process = Object.keys(coins)
-            .filter(ticker => coins[ticker].kucoin);
+  getPrices: async function (coins) {
+    let tickers_to_process = Object.keys(coins).filter(
+      (ticker) => coins[ticker].kucoin
+    );
 
-        return Promise.all(tickers_to_process.map(ticker => fetch(`https://api.kucoin.com/api/v1/market/orderbook/level1?symbol=${coins[ticker].kucoin}`)))
-            .then(responses => Promise.all(responses.map(res => res.json())))
-            .then(values => {
-                return values.reduce((object, price, index) => {
-                    if(price.data) {
-                        object [tickers_to_process[index]] = parseFloat(price.data.price)
-                        return object;
-                    }
-                }, {})
-            })
-            .catch(function(error) {
-                console.error(error)
-            })
-    }
-}
+    return Promise.all(
+      tickers_to_process.map((ticker) =>
+        fetch(
+          `https://api.kucoin.com/api/v1/market/orderbook/level1?symbol=${coins[ticker].kucoin}`
+        )
+      )
+    )
+      .then((responses) => Promise.all(responses.map((res) => res.json())))
+      .then((values) => {
+        return values.reduce((object, price, index) => {
+          if (price.data) {
+            object[tickers_to_process[index]] =
+              (parseFloat(price.data.bestBid) +
+                parseFloat(price.data.bestAsk)) /
+              2;
+            return object;
+          }
+        }, {});
+      })
+      .catch(function (error) {
+        console.error(error);
+      });
+  },
+};

--- a/functions.js
+++ b/functions.js
@@ -26,6 +26,24 @@ module.exports = {
   /**
    * @return {number}
    */
+  GetAvgPrice: function (bid, ask, last){
+    if (!(bid * ask)) {
+      return 0;
+    }
+
+    if (last <= bid) {
+      return parseFloat(bid);
+    }
+    if (last >= ask) {
+      return parseFloat(ask);
+    }
+
+    return parseFloat(last);
+  },
+
+  /**
+   * @return {number}
+   */
   GetMedianPrice: function (data, ticker) {
     let values = data.reduce((object, prices) => {
       if (prices?.hasOwnProperty(ticker)) {

--- a/functions.js
+++ b/functions.js
@@ -27,18 +27,22 @@ module.exports = {
    * @return {number}
    */
   GetAvgPrice: function (bid, ask, last){
-    if (!(bid * ask)) {
+    bid = parseFloat(bid);
+    ask = parseFloat(ask);
+    last = parseFloat(last);
+
+    if (!(bid * ask) || bid > ask || ask < bid) {
       return 0;
     }
 
     if (last <= bid) {
-      return parseFloat(bid);
+      return bid;
     }
     if (last >= ask) {
-      return parseFloat(ask);
+      return ask;
     }
 
-    return parseFloat(last);
+    return last;
   },
 
   /**

--- a/functions.js
+++ b/functions.js
@@ -5,7 +5,7 @@ module.exports = {
   /**
    * @return {boolean}
    */
-  IsDifferentEnough: function (price_old, price_new) {
+  IsDifferentEnough: function (relativeDiff, price_old, price_new) {
     const max_decimals = Math.max(price_new.decimals, price_old.decimals);
     const old_multiplier =
       price_old.multiplier *
@@ -19,8 +19,7 @@ module.exports = {
         : 1);
 
     return (
-      Math.abs(new_multiplier - old_multiplier) >=
-      old_multiplier * config.RELATIVE_DIFF
+      Math.abs(new_multiplier - old_multiplier) >= old_multiplier * relativeDiff
     );
   },
 

--- a/index.js
+++ b/index.js
@@ -133,7 +133,6 @@ const MainnetCoins = {
     kucoin: "BTC-USDT",
     gate: "btc_usdt",
   },
-  /*
   "aaaaaa20d9e0e2461697782ef11675f668207961.factory.bridge.near": {
     decimals: 18,
     coingecko: "aurora-near",
@@ -141,8 +140,7 @@ const MainnetCoins = {
     huobi: "aurorausdt",
     kucoin: "AURORA-USDT",
     gate: "aurora_usdt",
-  }
-   */
+  },
 };
 
 const MainnetComputeCoins = {

--- a/index.js
+++ b/index.js
@@ -313,17 +313,13 @@ async function main() {
   );
 
   const tickers = Object.keys(coins).concat(Object.keys(computeCoins));
-  const relativeDiffs = tickers.reduce(
-    agg,
-    (ticker) => {
-      agg[ticker] =
-        coins[ticker]?.relativeDiff ||
-        computeCoins[ticker]?.relativeDiff ||
-        config.RELATIVE_DIFF;
-      return agg;
-    },
-    {}
-  );
+  const relativeDiffs = tickers.reduce((agg, ticker) => {
+    agg[ticker] =
+      coins[ticker]?.relativeDiff ||
+      computeCoins[ticker]?.relativeDiff ||
+      config.RELATIVE_DIFF;
+    return agg;
+  }, {});
 
   const raw_oracle_price_data = await near.NearView(
     config.CONTRACT_ID,

--- a/index.js
+++ b/index.js
@@ -76,6 +76,7 @@ const TestnetCoins = {
     huobi: "aurorausdt",
     kucoin: "AURORA-USDT",
     gate: "aurora_usdt",
+    relativeDiff: 0.01, // 1%
   },
 };
 
@@ -140,6 +141,7 @@ const MainnetCoins = {
     huobi: "aurorausdt",
     kucoin: "AURORA-USDT",
     gate: "aurora_usdt",
+    relativeDiff: 0.01, // 1%
   },
 };
 
@@ -311,6 +313,17 @@ async function main() {
   );
 
   const tickers = Object.keys(coins).concat(Object.keys(computeCoins));
+  const relativeDiffs = tickers.reduce(
+    agg,
+    (ticker) => {
+      agg[ticker] =
+        coins[ticker]?.relativeDiff ||
+        computeCoins[ticker]?.relativeDiff ||
+        config.RELATIVE_DIFF;
+      return agg;
+    },
+    {}
+  );
 
   const raw_oracle_price_data = await near.NearView(
     config.CONTRACT_ID,
@@ -332,7 +345,7 @@ async function main() {
     {}
   );
 
-  await bot.updatePrices(tickers, old_prices, new_prices, state);
+  await bot.updatePrices(relativeDiffs, old_prices, new_prices, state);
 
   SaveJson(state, config.STATE_FILENAME);
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "near-api-js": "^0.42.0"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "jest func.test.js --useStderr --verbose false"
   },
   "repository": {
     "type": "git",

--- a/tests/func.test.js
+++ b/tests/func.test.js
@@ -11,6 +11,10 @@ test("Test GetAvgPrice", () => {
     expect(GetAvgPrice(0, 30, 10)).toBe(0);
     expect(GetAvgPrice(20, 0, 10)).toBe(0);
     expect(GetAvgPrice(0, 0, 0)).toBe(0);
+    expect(GetAvgPrice("20", "30", "25")).toBe(25);
+    expect(GetAvgPrice("20", "30", "40")).toBe(30);
+    expect(GetAvgPrice("20", "30", "10")).toBe(20);
+    expect(GetAvgPrice(30, 20, 25)).toBe(0);
 });
 
 test("Test IsDifferentEnough", () => {

--- a/tests/func.test.js
+++ b/tests/func.test.js
@@ -1,8 +1,17 @@
-const { IsDifferentEnough, GetMedianPrice } = require("./../functions");
+const { IsDifferentEnough, GetMedianPrice, GetAvgPrice } = require("./../functions");
 
 const MakeNum = (multiplier, decimals) => {
   return { multiplier, decimals };
 };
+
+test("Test GetAvgPrice", () => {
+    expect(GetAvgPrice(20, 30, 25)).toBe(25);
+    expect(GetAvgPrice(20, 30, 40)).toBe(30);
+    expect(GetAvgPrice(20, 30, 10)).toBe(20);
+    expect(GetAvgPrice(0, 30, 10)).toBe(0);
+    expect(GetAvgPrice(20, 0, 10)).toBe(0);
+    expect(GetAvgPrice(0, 0, 0)).toBe(0);
+});
 
 test("Test IsDifferentEnough", () => {
   const relDiff = 0.005;

--- a/tests/func.test.js
+++ b/tests/func.test.js
@@ -1,56 +1,106 @@
-const {IsDifferentEnough, GetMedianPrice} = require("./../functions");
+const { IsDifferentEnough, GetMedianPrice } = require("./../functions");
 
 const MakeNum = (multiplier, decimals) => {
-    return {multiplier, decimals}
-}
+  return { multiplier, decimals };
+};
 
-test('Test IsDifferentEnough', () => {
-    expect(IsDifferentEnough(MakeNum(10, 0), MakeNum(11, 0))).toBe(true);
-    expect(IsDifferentEnough(MakeNum(11, 0), MakeNum(10, 0))).toBe(true);
-    expect(IsDifferentEnough(MakeNum(11, 0), MakeNum(11, 0))).toBe(false);
+test("Test IsDifferentEnough", () => {
+  const relDiff = 0.005;
+  expect(IsDifferentEnough(relDiff, MakeNum(10, 0), MakeNum(11, 0))).toBe(true);
+  expect(IsDifferentEnough(relDiff, MakeNum(11, 0), MakeNum(10, 0))).toBe(true);
+  expect(IsDifferentEnough(relDiff, MakeNum(11, 0), MakeNum(11, 0))).toBe(
+    false
+  );
 
-    expect(IsDifferentEnough(MakeNum(10, 10), MakeNum(11, 10))).toBe(true);
-    expect(IsDifferentEnough(MakeNum(11, 10), MakeNum(10, 10))).toBe(true);
-    expect(IsDifferentEnough(MakeNum(11, 10), MakeNum(11, 10))).toBe(false);
+  expect(IsDifferentEnough(relDiff, MakeNum(10, 10), MakeNum(11, 10))).toBe(
+    true
+  );
+  expect(IsDifferentEnough(relDiff, MakeNum(11, 10), MakeNum(10, 10))).toBe(
+    true
+  );
+  expect(IsDifferentEnough(relDiff, MakeNum(11, 10), MakeNum(11, 10))).toBe(
+    false
+  );
 
-    expect(IsDifferentEnough(MakeNum(100, 10), MakeNum(10, 9))).toBe(false);
-    expect(IsDifferentEnough(MakeNum(10, 9), MakeNum(100, 10))).toBe(false);
+  expect(IsDifferentEnough(relDiff, MakeNum(100, 10), MakeNum(10, 9))).toBe(
+    false
+  );
+  expect(IsDifferentEnough(relDiff, MakeNum(10, 9), MakeNum(100, 10))).toBe(
+    false
+  );
 
-    expect(IsDifferentEnough(MakeNum(101, 10), MakeNum(10, 9))).toBe(true);
-    expect(IsDifferentEnough(MakeNum(10, 9), MakeNum(101, 10))).toBe(true);
-    expect(IsDifferentEnough(MakeNum(99, 10), MakeNum(10, 9))).toBe(true);
-    expect(IsDifferentEnough(MakeNum(10, 9), MakeNum(99, 10))).toBe(true);
+  expect(IsDifferentEnough(relDiff, MakeNum(101, 10), MakeNum(10, 9))).toBe(
+    true
+  );
+  expect(IsDifferentEnough(relDiff, MakeNum(10, 9), MakeNum(101, 10))).toBe(
+    true
+  );
+  expect(IsDifferentEnough(relDiff, MakeNum(99, 10), MakeNum(10, 9))).toBe(
+    true
+  );
+  expect(IsDifferentEnough(relDiff, MakeNum(10, 9), MakeNum(99, 10))).toBe(
+    true
+  );
 
-    expect(IsDifferentEnough(MakeNum(101, 40), MakeNum(10, 0))).toBe(true);
-    expect(IsDifferentEnough(MakeNum(10, 0), MakeNum(101, 40))).toBe(true);
+  expect(IsDifferentEnough(relDiff, MakeNum(101, 40), MakeNum(10, 0))).toBe(
+    true
+  );
+  expect(IsDifferentEnough(relDiff, MakeNum(10, 0), MakeNum(101, 40))).toBe(
+    true
+  );
 
-    expect(IsDifferentEnough(MakeNum(101, 40), MakeNum(10100, 42))).toBe(false);
-    expect(IsDifferentEnough(MakeNum(100000000000000000000, 20), MakeNum(10, 1))).toBe(false);
+  expect(IsDifferentEnough(relDiff, MakeNum(101, 40), MakeNum(10100, 42))).toBe(
+    false
+  );
+  expect(
+    IsDifferentEnough(
+      relDiff,
+      MakeNum(100000000000000000000, 20),
+      MakeNum(10, 1)
+    )
+  ).toBe(false);
 });
 
-test('Test GetMedianPrice', () => {
-    expect(GetMedianPrice(
-        [{"ticker": 1.2}, {"ticker": 1.3}, {"ticker": 1.4}, {"ticker": 1.5}, {"ticker": 1.6}],
-        "ticker"))
-        .toBe(1.4);
+test("Test GetMedianPrice", () => {
+  expect(
+    GetMedianPrice(
+      [
+        { ticker: 1.2 },
+        { ticker: 1.3 },
+        { ticker: 1.4 },
+        { ticker: 1.5 },
+        { ticker: 1.6 },
+      ],
+      "ticker"
+    )
+  ).toBe(1.4);
 
-    expect(GetMedianPrice(
-        [{"ticker": 110.2}, {"ticker": 210.3}, {"ticker": 310.4}, {"ticker": 410.5}, {"ticker": 510.6}],
-        "ticker"))
-        .toBe(310.4);
+  expect(
+    GetMedianPrice(
+      [
+        { ticker: 110.2 },
+        { ticker: 210.3 },
+        { ticker: 310.4 },
+        { ticker: 410.5 },
+        { ticker: 510.6 },
+      ],
+      "ticker"
+    )
+  ).toBe(310.4);
 
-    expect(GetMedianPrice(
-        [{"ticker": 110.2}, {"ticker": 210.3}, {"ticker": 310.4}, {"ticker": 410.5}],
-        "ticker"))
-        .toBe((210.3 + 310.4) / 2);
+  expect(
+    GetMedianPrice(
+      [
+        { ticker: 110.2 },
+        { ticker: 210.3 },
+        { ticker: 310.4 },
+        { ticker: 410.5 },
+      ],
+      "ticker"
+    )
+  ).toBe((210.3 + 310.4) / 2);
 
-    expect(GetMedianPrice(
-        [],
-        "ticker"))
-        .toBe(0);
+  expect(GetMedianPrice([], "ticker")).toBe(0);
 
-    expect(GetMedianPrice(
-        [{"ticker": 1}],
-        "ticker"))
-        .toBe(1);
+  expect(GetMedianPrice([{ ticker: 1 }], "ticker")).toBe(1);
 });


### PR DESCRIPTION
It also includes a few fixes for the API data:
- instead of using latest price for some exchanges, it uses the avg price between ask and bid.
- aurora token price volatility is increased from 0.5% to 1%. Meaning the price of aurora token will be reported earlier if the new price is different from the previous price by 1%. 