### PR TITLE
Claim NEAR on demand

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -53,6 +53,12 @@ module.exports = {
       console.log(`!!! Reporting version of the bot: ${pjson?.version}`);
     }
 
+    const currentBalance = parseFloat(await near.CurrentBalance(config.NEAR_ACCOUNT_ID)) / 1e24;
+    if (currentBalance < config.MIN_CLAIM_NEAR_BALANCE) {
+      console.log(`!!! Current balance ${currentBalance} is less than ${config.MIN_CLAIM_NEAR_BALANCE}. Claiming NEAR`);
+      txParameters.claim_near = true;
+    }
+
     if (prices_to_update.length || !!txParameters.version ) {
       await near.NearCall(
         config.NEAR_ACCOUNT_ID,

--- a/config.js
+++ b/config.js
@@ -42,6 +42,8 @@ module.exports = {
     ? parseFloat(process.env.MIN_USN_LIQUIDITY_IN_POOL)
     : 10_000 * 1e18,
 
+  MIN_CLAIM_NEAR_BALANCE: process.env.MIN_CLAIM_NEAR_BALANCE ? parseFloat(process.env.MIN_CLAIM_NEAR_BALANCE) : 10,
+
   getConfig: (env) => {
     switch (env) {
       case "production":

--- a/index.js
+++ b/index.js
@@ -234,8 +234,8 @@ const MainnetComputeCoins = {
         );
         const stNearMultiplier =
           parseFloat(rawStNearState.st_near_price) / 1e24;
-        // TODO: Update 1.25 in about 1 year (May, 2023)
-        if (stNearMultiplier < 1.0 || stNearMultiplier > 1.25) {
+        // TODO: Update 1.34 in about 1 year (Jul, 2024)
+        if (stNearMultiplier < 1.21 || stNearMultiplier > 1.34) {
           console.error("stNearMultiplier is out of range:", stNearMultiplier);
           return null;
         }
@@ -262,8 +262,8 @@ const MainnetComputeCoins = {
           {}
         );
         const liNearMultiplier = parseFloat(rawLiNearPrice) / 1e24;
-        // TODO: Update 1.25 in about 1 year (May, 2023)
-        if (liNearMultiplier < 1.0 || liNearMultiplier > 1.15) {
+        // TODO: Update 1.25 in about 1 year (July, 2024)
+        if (liNearMultiplier < 1.13 || liNearMultiplier > 1.25) {
           console.error("liNearMultiplier is out of range:", liNearMultiplier);
           return null;
         }
@@ -290,8 +290,8 @@ const MainnetComputeCoins = {
             {}
         );
         const nearXMultiplier = parseFloat(nearXPrice) / 1e24;
-        // TODO: Update 1.2 in about 1 year (May, 2023)
-        if (nearXMultiplier < 1.0 || nearXMultiplier > 1.15) {
+        // TODO: Update 1.25 in about 1 year (July, 2024)
+        if (nearXMultiplier < 1.13 || nearXMultiplier > 1.25) {
           console.error("nearXMultiplier is out of range:", nearXMultiplier);
           return null;
         }

--- a/near.js
+++ b/near.js
@@ -14,6 +14,15 @@ const CREDENTIALS_DIR =
 const GAS = "50000000000000";
 
 module.exports = {
+  CurrentBalance: async function (accountId) {
+    const nearRpc = new nearApi.providers.JsonRpcProvider(nearConfig.nodeUrl);
+    const account = new nearApi.Account({ provider: nearRpc }, accountId);
+
+    const state = await account.state();
+
+    return state.amount;
+  },
+
   NearView: async function (contract, operation, parameters) {
     const nearRpc = new nearApi.providers.JsonRpcProvider(nearConfig.nodeUrl);
     const account = new nearApi.Account({ provider: nearRpc });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "near-oracle-bot",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "description": "",
   "main": "index.js",
   "dependencies": {


### PR DESCRIPTION
- Adjust limits for liquid staked NEAR
- Claim NEAR only when the balance is lower than configured value. 10 NEAR by default. See https://github.com/NearDeFi/price-oracle/pull/5