### PR TITLE
Add native USDC. Don't report non-whitelisted assets

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -4,7 +4,7 @@ const { IsDifferentEnough } = require("./functions");
 const pjson = require('./package.json');
 
 module.exports = {
-  updatePrices: async function (relativeDiffs, old_prices, new_prices, state) {
+  updatePrices: async function (relativeDiffs, old_prices, new_prices, state, liveAssets) {
     const current_time = new Date().getTime();
     let prices_to_update = [];
     const all_prices_updates = [];
@@ -14,6 +14,10 @@ module.exports = {
       console.log(
         `Compare ${ticker}: ${old_price.multiplier.toString()} and ${new_price.multiplier.toString()}`
       );
+      if (liveAssets && !liveAssets.includes(ticker)) {
+        console.log(`!!! ${ticker} is not whitelisted. Skipping`);
+        return;
+      }
       if (new_price.multiplier > 0) {
         const price_update = {
           asset_id: ticker,

--- a/bot.js
+++ b/bot.js
@@ -14,7 +14,7 @@ module.exports = {
       console.log(
         `Compare ${ticker}: ${old_price.multiplier.toString()} and ${new_price.multiplier.toString()}`
       );
-      if (liveAssets && !liveAssets.includes(ticker)) {
+      if (liveAssets && !liveAssets.has(ticker)) {
         console.log(`!!! ${ticker} is not whitelisted. Skipping`);
         return;
       }

--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ const chainlink = require("./feeds/chainlink");
 const refExchange = require("./feeds/refExchange");
 const { GetMedianPrice, LoadJson, SaveJson } = require("./functions");
 const pjson = require('./package.json');
+const {NearView} = require("./near");
 
 console.log(`NEAR Price Oracle Validator Bot, v.${pjson?.version}`);
 
@@ -313,6 +314,10 @@ const MainnetComputeCoins = {
   "usdt.tether-token.near": {
     dependencyCoin: "dac17f958d2ee523a2206206994597c13d831ec7.factory.bridge.near",
     computeCall: async (dependencyPrice) => dependencyPrice,
+  },
+  "17208628f84f5d6ad33f0da3bbbeb27ffcb398eac501a31bd6ad2011e36133a1": {
+    dependencyCoin: "a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48.factory.bridge.near",
+    computeCall: async (dependencyPrice) => dependencyPrice,
   }
 };
 
@@ -322,6 +327,10 @@ const TestnetComputeCoins = {
     computeCall: async (dependencyPrice) => dependencyPrice,
   },
   "usdn.testnet": computeUsn("usdn.testnet", "usdt.fakes.testnet", 356),
+  "3e2210e1184b45b64c8a434c0a7e7b23cc04ea7eb7a6c3c32520d03d4afcb8af": {
+    dependencyCoin: "usdc.fakes.testnet",
+    computeCall: async (dependencyPrice) => dependencyPrice,
+  }
 };
 
 const mainnet = nearConfig.networkId === "mainnet";
@@ -394,7 +403,7 @@ async function main() {
     return agg;
   }, {});
 
-  const raw_oracle_price_data = await near.NearView(
+  const [raw_oracle_price_data, rawAssets] = await Promise.all([near.NearView(
     config.CONTRACT_ID,
     "get_oracle_price_data",
     {
@@ -402,7 +411,12 @@ async function main() {
       asset_ids: tickers,
       recency_duration_sec: Math.floor(config.MAX_NO_REPORT_DURATION / 1000),
     }
-  );
+  ), near.NearView(config.CONTRACT_ID,
+    "get_assets",
+    {
+    })]);
+
+  const liveAssets = new Set(rawAssets.map(asset => asset[0]));
 
   const old_prices = raw_oracle_price_data.prices.reduce(
     (obj, item) =>
@@ -414,7 +428,7 @@ async function main() {
     {}
   );
 
-  await bot.updatePrices(relativeDiffs, old_prices, new_prices, state);
+  await bot.updatePrices(relativeDiffs, old_prices, new_prices, state, liveAssets);
 
   SaveJson(state, config.STATE_FILENAME);
 }

--- a/index.js
+++ b/index.js
@@ -12,7 +12,6 @@ const chainlink = require("./feeds/chainlink");
 const refExchange = require("./feeds/refExchange");
 const { GetMedianPrice, LoadJson, SaveJson } = require("./functions");
 const pjson = require('./package.json');
-const {NearView} = require("./near");
 
 console.log(`NEAR Price Oracle Validator Bot, v.${pjson?.version}`);
 
@@ -411,10 +410,11 @@ async function main() {
       asset_ids: tickers,
       recency_duration_sec: Math.floor(config.MAX_NO_REPORT_DURATION / 1000),
     }
-  ), near.NearView(config.CONTRACT_ID,
+  ), near.NearView(
+    config.CONTRACT_ID,
     "get_assets",
-    {
-    })]);
+    {}
+  )]);
 
   const liveAssets = new Set(rawAssets.map(asset => asset[0]));
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "near-oracle-bot",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "",
   "main": "index.js",
   "dependencies": {


### PR DESCRIPTION
- Add support for native USDC.
- Fix: don't report assets that are not live on the contract.